### PR TITLE
Log message are meaningless when config file error occurs

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,8 +41,8 @@ func initConfig() {
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 
 	if configFile != "" {
-		log.Warn().Msgf("Using config file: %v", viper.ConfigFileUsed())
 		viper.SetConfigFile(configFile)
+		log.Warn().Msgf("Using config file: %v", viper.ConfigFileUsed())
 	} else {
 		viper.AddConfigPath("config")
 		viper.AddConfigPath("../../config")

--- a/main.go
+++ b/main.go
@@ -53,8 +53,8 @@ func initConfig() {
 	}
 	viper.SetConfigType("yaml")
 
-	if err := viper.ReadInConfig(); err == nil {
-		log.Warn().Msgf("Using config file: %v", viper.ConfigFileUsed())
+	if err := viper.ReadInConfig(); err != nil {
+		log.Panic().Err(err).Msg("Cannot read config file")
 	}
 	debug = viper.GetBool("debug")
 	databaseURL = viper.GetString("database")


### PR DESCRIPTION
Due to:
1. Wrong order of SetConfigFile and log
2. Logic of handling errors for viper.ReadInConfig()

Log messages didn't help to identify errors with config.
For incorrect config file log messages were: 
```
{"level":"warn","time":"2022-12-21T09:36:35Z","message":"Using config file: "}
{"level":"panic","error":"failed to connect to `host=/tmp user=root database=`: dial error (dial unix /tmp/.s.PGSQL.5432: connect: no such file or directory)","time":"2022-12-21T09:36:35Z","message":"Unable to connect to database: "}
```
After refactoring log messages become clearer:
```
{"level":"warn","time":"2022-12-21T13:15:55+04:00","message":"Using config file: /config/config.yaml"}
{"level":"panic","error":"open /config/config.yaml: no such file or directory","time":"2022-12-21T13:15:55+04:00","message":"Cannot read config file"}
```